### PR TITLE
Use GPT-5 high reasoning exclusively

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ A beautiful, modern web interface for the Codex CLI that transforms the command-
 
 ### 🎯 Core Functionality
 - **Chat Interface**: Intuitive conversation-style interaction with Codex
-- **Model Selection**: Choose from multiple AI models (GPT-5, GPT-4, Claude 3, O3, O1, etc.)
-- **Reasoning Levels**: Configure reasoning effort (Low, Medium, High)
+- **Model**: Always uses GPT-5 with high reasoning for optimal performance
 - **Sandbox Controls**: Multiple security levels (Read-only, Workspace-write, Full-access)
 - **Approval Policies**: Control when human approval is required
 
@@ -64,18 +63,8 @@ npm run dev
 
 ## 🎛️ Configuration
 
-### Model & Reasoning Selection
-Choose from available AI models with integrated reasoning levels:
-- **GPT-5**: Latest OpenAI model (Low/Medium/High reasoning)
-- **O3**: OpenAI reasoning model (Low/Medium/High reasoning)  
-- **O4-Mini**: Compact OpenAI model (Low/Medium/High reasoning)
-
-**Note**: Model routing can be configured in the codex config.toml file
-
-### Reasoning Levels
-- **Low**: Fast responses (~10s thinking time)
-- **Medium**: Balanced performance (~15s thinking time)
-- **High**: Deep thinking (~30s thinking time)
+### Model & Reasoning
+Codex UI uses **GPT-5 with high reasoning** for all interactions. Model routing is fixed for optimal performance.
 
 ### Thinking Progress Indicator
 - **Real-time timer**: Shows elapsed thinking time
@@ -149,8 +138,6 @@ The UI supports automatic dark/light theme switching based on your system prefer
 
 ### Configuration
 All settings are automatically saved to localStorage and persist between sessions:
-- Model selection
-- Reasoning levels
 - Security settings
 - Theme preferences
 - UI options
@@ -207,7 +194,6 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ## 🔗 Related Projects
 
 - [OpenAI Codex](https://openai.com/codex) - The underlying AI model
-- [Anthropic Claude](https://anthropic.com) - Alternative AI model
 - [Cursor IDE](https://cursor.sh) - AI-powered code editor
 
 ## 🆘 Support

--- a/app.js
+++ b/app.js
@@ -2,8 +2,6 @@
 class CodexUI {
     constructor() {
         this.config = {
-            model: 'gpt-5',
-            reasoningLevel: 'medium',
             reasoningSummaries: 'auto',
             sandboxMode: 'read-only',
             approvalPolicy: 'never',
@@ -47,12 +45,6 @@ class CodexUI {
         messageInput.addEventListener('input', () => this.adjustTextareaHeight());
         messageInput.addEventListener('keydown', (e) => this.handleKeyDown(e));
         sendBtn.addEventListener('click', () => this.sendMessage());
-        
-        // Configuration changes (UI only - backend always uses GPT-5 high)
-        document.getElementById('modelSelect').addEventListener('change', (e) => {
-            // Show info that backend always uses GPT-5 high
-            this.addMessage('system', `⚙️ **Model Selection**\n\n*Note: Backend always uses GPT-5 with high reasoning for optimal performance, regardless of UI selection.*`);
-        });
         
         document.getElementById('reasoningSummaries').addEventListener('change', (e) => {
             this.config.reasoningSummaries = e.target.value;
@@ -154,8 +146,6 @@ class CodexUI {
             
             // Add configuration
             formData.append('message', message);
-            formData.append('model', this.config.model);
-            formData.append('reasoningLevel', this.config.reasoningLevel);
             formData.append('reasoningSummaries', this.config.reasoningSummaries);
             formData.append('sandboxMode', this.config.sandboxMode);
             formData.append('approvalPolicy', this.config.approvalPolicy);
@@ -200,9 +190,9 @@ class CodexUI {
     simulateCodexResponse(message, command) {
         const responses = [
             `I'll help you with that. Let me analyze your request: "${message}"`,
-            `Based on your configuration (Model: ${this.config.model}, Reasoning: ${this.config.reasoningLevel}), here's what I found...`,
+            `Based on your configuration (Model: GPT-5, Reasoning: High), here's what I found...`,
             `I understand you want to work with: "${message}". Let me break this down step by step.`,
-            `Processing your request with the following settings:\n- Model: ${this.config.model}\n- Sandbox: ${this.config.sandboxMode}\n- Working Directory: ${this.config.workingDir}\n\nHere's my response...`
+            `Processing your request with the following settings:\n- Model: GPT-5 (High reasoning)\n- Sandbox: ${this.config.sandboxMode}\n- Working Directory: ${this.config.workingDir}\n\nHere's my response...`
         ];
         
         const randomResponse = responses[Math.floor(Math.random() * responses.length)];
@@ -396,13 +386,8 @@ class CodexUI {
                 elapsedElement.textContent = `${elapsed.toFixed(1)}s`;
             }
             
-            // Estimate based on reasoning level and elapsed time
-            let estimatedTotal = 15; // default
-            if (this.config.reasoningLevel === 'low') {
-                estimatedTotal = 10;
-            } else if (this.config.reasoningLevel === 'high') {
-                estimatedTotal = 30;
-            }
+            // Estimate based on high reasoning effort
+            let estimatedTotal = 30;
             
             // Adjust estimate as time progresses
             if (elapsed > estimatedTotal) {
@@ -463,33 +448,6 @@ class CodexUI {
             document.getElementById('sandboxMode').value = 'danger-full-access';
             this.saveSettings();
             this.addMessage('system', '⚠️ Danger mode enabled: Commands will execute without sandboxing!', [], 'error');
-        }
-    }
-    
-    async updateCodexConfig(model, reasoningLevel) {
-        try {
-            const response = await fetch(`${this.config.apiEndpoint}/api/codex/config`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify({ model, reasoningLevel })
-            });
-            
-            if (!response.ok) {
-                const errorData = await response.json();
-                throw new Error(errorData.error || `HTTP ${response.status}`);
-            }
-            
-            const data = await response.json();
-            console.log('Codex config updated:', data);
-            
-            // Show success message
-            this.addMessage('system', `⚙️ **Configuration Updated**\n\nModel: ${model}\nReasoning Level: ${reasoningLevel}\n\n*Codex config file has been updated. New settings will apply to future conversations.*`);
-            
-        } catch (error) {
-            console.error('Error updating Codex config:', error);
-            this.addMessage('system', `❌ **Configuration Update Failed**\n\nError: ${error.message}\n\nFalling back to runtime configuration only.`, [], 'error');
         }
     }
     
@@ -710,8 +668,6 @@ class CodexUI {
         }
         
         // Apply loaded settings to UI
-        const modelValue = `${this.config.model},${this.config.reasoningLevel}`;
-        document.getElementById('modelSelect').value = modelValue;
         document.getElementById('reasoningSummaries').value = this.config.reasoningSummaries;
         document.getElementById('sandboxMode').value = this.config.sandboxMode;
         document.getElementById('approvalPolicy').value = this.config.approvalPolicy;

--- a/index.html
+++ b/index.html
@@ -35,20 +35,10 @@
             <aside class="sidebar">
                 <div class="config-section">
                     <h3><i class="fas fa-brain"></i> Model Configuration</h3>
-                    
+
                     <div class="form-group">
-                        <label for="modelSelect">Model & Reasoning Level</label>
-                        <select id="modelSelect" class="form-control">
-                            <option value="gpt-5,high" selected>GPT-5 (High reasoning) ✓ Active</option>
-                            <option value="gpt-5,medium">GPT-5 (Medium reasoning)</option>
-                            <option value="gpt-5,low">GPT-5 (Low reasoning)</option>
-                            <option value="o3,high">O3 (High reasoning)</option>
-                            <option value="o3,medium">O3 (Medium reasoning)</option>
-                            <option value="o3,low">O3 (Low reasoning)</option>
-                            <option value="o4-mini,high">O4-Mini (High reasoning)</option>
-                            <option value="o4-mini,medium">O4-Mini (Medium reasoning)</option>
-                            <option value="o4-mini,low">O4-Mini (Low reasoning)</option>
-                        </select>
+                        <label>Model</label>
+                        <p>GPT-5 (High reasoning) ✓ Active</p>
                         <small class="form-text">Backend always uses GPT-5 with high reasoning for optimal performance</small>
                     </div>
 

--- a/server.js
+++ b/server.js
@@ -120,14 +120,7 @@ app.get('/api/models', async (req, res) => {
     try {
         // In a real implementation, you might query the Codex CLI for available models
         const models = [
-            { id: 'gpt-5', name: 'GPT-5', description: 'Latest OpenAI model' },
-            { id: 'gpt-4', name: 'GPT-4', description: 'Previous generation OpenAI model' },
-            { id: 'gpt-4-turbo', name: 'GPT-4 Turbo', description: 'Faster GPT-4 variant' },
-            { id: 'claude-3-opus', name: 'Claude 3 Opus', description: 'Anthropic\'s most capable model' },
-            { id: 'claude-3-sonnet', name: 'Claude 3 Sonnet', description: 'Balanced Anthropic model' },
-            { id: 'claude-3-haiku', name: 'Claude 3 Haiku', description: 'Fast Anthropic model' },
-            { id: 'o3', name: 'O3', description: 'OpenAI reasoning model' },
-            { id: 'o1', name: 'O1', description: 'OpenAI reasoning model' }
+            { id: 'gpt-5', name: 'GPT-5', description: 'Latest OpenAI model (High reasoning only)' }
         ];
         
         res.json({ models });
@@ -142,8 +135,6 @@ app.post('/api/codex/execute', upload.array('files'), async (req, res) => {
     try {
         const {
             message,
-            model = 'gpt-5',
-            reasoningLevel = 'medium',
             reasoningSummaries = 'auto',
             sandboxMode = 'read-only',
             approvalPolicy = 'never',


### PR DESCRIPTION
## Summary
- Limit UI to GPT-5 with high reasoning and remove model picker
- Drop unused model logic from frontend and backend
- Document fixed GPT-5 high model in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_689d8b6bc628832d8f43835d6408846e