### PR TITLE
Use Gemini to clean Codex output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.5",
+        "dotenv": "^16.4.5",
         "express": "^4.18.2",
         "multer": "^1.4.5-lts.1"
       },
@@ -310,6 +311,18 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "dependencies": {
     "express": "^4.18.2",
     "cors": "^2.8.5",
-    "multer": "^1.4.5-lts.1"
+    "multer": "^1.4.5-lts.1",
+    "dotenv": "^16.4.5"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ const { spawn } = require('child_process');
 const fs = require('fs').promises;
 const multer = require('multer');
 const os = require('os');
+require('dotenv').config();
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -198,15 +199,25 @@ app.post('/api/codex/execute', upload.array('files'), async (req, res) => {
             }
         }
 
-        // Clean up the response
+        // Clean up the response using Gemini
         console.log('Raw Codex stdout:', JSON.stringify(result.stdout));
         console.log('Raw Codex stderr:', JSON.stringify(result.stderr));
-        
-        const cleanedResponse = cleanCodexResponse(result.stdout);
+
+        let finalResponse = '';
+        try {
+            finalResponse = await stripReasoningWithGemini(result.stdout);
+        } catch (geminiError) {
+            console.error('Gemini processing failed:', geminiError);
+        }
+
+        if (!finalResponse) {
+            const fallback = cleanCodexResponse(result.stdout);
+            finalResponse = fallback.response;
+        }
 
         res.json({
-            response: cleanedResponse.response,
-            thinking: cleanedResponse.thinking,
+            response: finalResponse || 'No response from Codex',
+            thinking: '',
             error: result.stderr,
             exitCode: result.exitCode,
             timestamp: new Date().toISOString()
@@ -397,6 +408,30 @@ app.get('/api/codex/sessions', async (req, res) => {
         });
     }
 });
+
+// Use Google Gemini to strip thinking/analysis from Codex output
+async function stripReasoningWithGemini(rawText) {
+    const apiKey = process.env.api;
+    if (!apiKey) {
+        console.warn('Gemini API key not configured');
+        return '';
+    }
+
+    const prompt = `From the input, strip all thinking/analysis and return only the stated answer. Do not summarize or rephrase; copy the answer verbatim. No labels or extra text.\n\n${rawText}`;
+
+    const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent?key=${apiKey}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            contents: [{ parts: [{ text: prompt }] }]
+        })
+    });
+
+    const data = await response.json();
+    const parts = data?.candidates?.[0]?.content?.parts;
+    const text = parts ? parts.map(p => p.text).join('') : '';
+    return text.trim();
+}
 
 // Execute Codex CLI command
 function executeCodex(args) {


### PR DESCRIPTION
## Summary
- call Google Gemini 2.5 Flash Lite to strip thinking text from Codex CLI responses
- load API key from `.env` via `dotenv`
- fall back to existing cleaner if Gemini is unavailable

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_689d8f50df8c832d9468771fd6b3a89d