### PR TITLE
Use Gemini to clean Codex output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,10 @@
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.5",
+        "dotenv": "^16.4.5",
         "express": "^4.18.2",
-        "multer": "^1.4.5-lts.1"
+        "multer": "^1.4.5-lts.1",
+        "node-fetch": "^2.7.0"
       },
       "devDependencies": {
         "nodemon": "^3.0.1"
@@ -310,6 +312,18 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -840,6 +854,26 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/nodemon": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.10.tgz",
@@ -1325,6 +1359,12 @@
         "nodetouch": "bin/nodetouch.js"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -1382,6 +1422,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -21,9 +21,11 @@
   "author": "Codex UI",
   "license": "MIT",
   "dependencies": {
-    "express": "^4.18.2",
     "cors": "^2.8.5",
-    "multer": "^1.4.5-lts.1"
+    "dotenv": "^16.4.5",
+    "express": "^4.18.2",
+    "multer": "^1.4.5-lts.1",
+    "node-fetch": "^2.7.0"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"

--- a/server.js
+++ b/server.js
@@ -204,10 +204,12 @@ app.post('/api/codex/execute', upload.array('files'), async (req, res) => {
         console.log('Raw Codex stdout:', JSON.stringify(result.stdout));
         console.log('Raw Codex stderr:', JSON.stringify(result.stderr));
 
+        // Prefer Gemini's cleaned response
         let finalResponse = '';
         try {
-            const geminiResult = await stripReasoningWithGemini(result.stdout);
-            if (geminiResult && !/thinking/i.test(geminiResult)) {
+            const rawOutput = [result.stdout, result.stderr].filter(Boolean).join('\n');
+            const geminiResult = await stripReasoningWithGemini(rawOutput);
+            if (geminiResult) {
                 finalResponse = geminiResult;
             }
         } catch (geminiError) {

--- a/server.js
+++ b/server.js
@@ -5,6 +5,8 @@ const { spawn } = require('child_process');
 const fs = require('fs').promises;
 const multer = require('multer');
 const os = require('os');
+require('dotenv').config();
+const fetch = global.fetch || require('node-fetch');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -198,15 +200,28 @@ app.post('/api/codex/execute', upload.array('files'), async (req, res) => {
             }
         }
 
-        // Clean up the response
+        // Clean up the response using Gemini
         console.log('Raw Codex stdout:', JSON.stringify(result.stdout));
         console.log('Raw Codex stderr:', JSON.stringify(result.stderr));
-        
-        const cleanedResponse = cleanCodexResponse(result.stdout);
+
+        let finalResponse = '';
+        try {
+            const geminiResult = await stripReasoningWithGemini(result.stdout);
+            if (geminiResult && !/thinking/i.test(geminiResult)) {
+                finalResponse = geminiResult;
+            }
+        } catch (geminiError) {
+            console.error('Gemini processing failed:', geminiError);
+        }
+
+        if (!finalResponse) {
+            const fallback = cleanCodexResponse(result.stdout);
+            finalResponse = fallback.response;
+        }
 
         res.json({
-            response: cleanedResponse.response,
-            thinking: cleanedResponse.thinking,
+            response: finalResponse || 'No response from Codex',
+            thinking: '',
             error: result.stderr,
             exitCode: result.exitCode,
             timestamp: new Date().toISOString()
@@ -398,6 +413,40 @@ app.get('/api/codex/sessions', async (req, res) => {
     }
 });
 
+// Use Google Gemini to strip thinking/analysis from Codex output
+async function stripReasoningWithGemini(rawText) {
+    const apiKey = process.env.api;
+    if (!apiKey) {
+        console.warn('Gemini API key not configured');
+        return '';
+    }
+
+    const prompt = `From the input, strip all thinking/analysis and return only the stated answer. Do not summarize or rephrase; copy the answer verbatim. No labels or extra text.\n\n${rawText}`;
+
+    try {
+        const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent?key=${apiKey}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                contents: [{ parts: [{ text: prompt }] }]
+            })
+        });
+
+        if (!response.ok) {
+            console.warn('Gemini API error:', response.status, await response.text());
+            return '';
+        }
+
+        const data = await response.json();
+        const parts = data?.candidates?.[0]?.content?.parts;
+        const text = parts ? parts.map(p => p.text).join('') : '';
+        return text.trim();
+    } catch (error) {
+        console.error('Gemini fetch failed:', error);
+        return '';
+    }
+}
+
 // Execute Codex CLI command
 function executeCodex(args) {
     return new Promise((resolve, reject) => {
@@ -537,10 +586,12 @@ function cleanCodexResponse(rawResponse) {
     };
 }
 
-app.listen(PORT, () => {
-    console.log(`🚀 Codex UI Server running on http://localhost:${PORT}`);
-    console.log(`📁 Serving files from: ${__dirname}`);
-    console.log(`🤖 Ready to interface with Codex CLI`);
-});
+if (require.main === module) {
+    app.listen(PORT, () => {
+        console.log(`🚀 Codex UI Server running on http://localhost:${PORT}`);
+        console.log(`📁 Serving files from: ${__dirname}`);
+        console.log(`🤖 Ready to interface with Codex CLI`);
+    });
+}
 
-module.exports = app;
+module.exports = { app, stripReasoningWithGemini, cleanCodexResponse };


### PR DESCRIPTION
## Summary
- ensure Gemini post-processing runs in Node by adding `node-fetch`
- handle Gemini API errors and fall back to local cleaner when needed
- export helper functions and only start server when run directly

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node -e "const {stripReasoningWithGemini, cleanCodexResponse}=require('./server'); const raw=require('./test_response.json').message; (async()=>{console.log('Gemini:', await stripReasoningWithGemini(raw)); console.log('Fallback:', cleanCodexResponse(raw).response);})();"` *(Gemini API key not configured)*

------
https://chatgpt.com/codex/tasks/task_b_689d8f50df8c832d9468771fd6b3a89d